### PR TITLE
Supports making request with json serialization

### DIFF
--- a/example/generated/Twitch/Twirp/Example/TwirpError.php
+++ b/example/generated/Twitch/Twirp/Example/TwirpError.php
@@ -49,7 +49,7 @@ final class TwirpError extends \Exception implements Error
     /**
      * {@inheritdoc}
      */
-    public function getMeta($key): string
+    public function getMeta(string $key): string
     {
         if (isset($this->meta[$key])) {
             return $this->meta[$key];

--- a/protoc-gen-twirp_php/templates/service/Client.php
+++ b/protoc-gen-twirp_php/templates/service/Client.php
@@ -48,9 +48,10 @@ final class {{ .Service | phpServiceName .File }}Client implements {{ .Service |
     private $streamFactory;
 
     /**
-     * @var boolean
+     * If set to true client will use JSON serialization instead of Protobuf.
+     * @var bool
      */
-    private $doProtobufRequest = true;
+    private $json = false;
 
     public function __construct(
         $addr,
@@ -77,7 +78,7 @@ final class {{ .Service | phpServiceName .File }}Client implements {{ .Service |
     }
 
     /**
-     * Returns a new client configured to do json request instead of doing protobuf request which is default and recommended.
+     * Returns a new client configured to use JSON serialization instead of Protobuf.
      */
     public static function newJson(
         $addr,
@@ -87,7 +88,7 @@ final class {{ .Service | phpServiceName .File }}Client implements {{ .Service |
     ): {{ .Service | phpServiceName .File }}Client
     {
         $client = new static($addr, $httpClient, $requestFactory, $streamFactory);
-        $client->doProtobufRequest = false;
+        $client->json = true;
 
         return $client;
     }
@@ -116,10 +117,10 @@ final class {{ .Service | phpServiceName .File }}Client implements {{ .Service |
      */
     private function doRequest(array $ctx, string $url, Message $in, Message $out): void
     {
-        if ($this->doProtobufRequest) {
-            $this->doProtobufRequest($ctx, $url, $in, $out);
-        } else {
+        if ($this->json) {
             $this->doJsonRequest($ctx, $url, $in, $out);
+        } else {
+            $this->doProtobufRequest($ctx, $url, $in, $out);
         }
     }
 


### PR DESCRIPTION
(For internal review)

For reference see these diff in auto generated code by official golang support for protobuf and json clients respectively:
- [Protobuf and json client](https://www.diffchecker.com/Nwl6H1zl)
- [Protobuf and json serialization and deserialization](https://www.diffchecker.com/lGjaJItz)

Pending:
- [ ] Tests
- [ ] Perf

```sh
// Followed build, tests command etc from upstream repo and...
go build ./protoc-gen-twirp_php/main.go

// To use locally compiled binary for php sdk generation out of proto files
protoc --twirp_php_out=gen/php --php_out=gen/php --plugin="protoc-gen-twirp_php=/Users/jitendraojha/github.com/jitendra-1217/twirp/main" common/health/v1/health_check_api.proto

// After this uses stork-php like repo (had in local) to test the sdk ^ with local stork. Note that needed to install lot of php-http stuff. Refer compser.json of upstream repo.